### PR TITLE
Split estimation report and listing of issues without estimates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ Style/StringLiterals:
 Bundler/OrderedGems:
   Enabled: false
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Metrics/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'roda'
 gem 'puma'
 gem 'zeitwerk'
 gem 'sucker_punch'
+gem 'activesupport', require: false
 
 group :development, :test do
   gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
@@ -22,6 +28,8 @@ GEM
     httparty (0.17.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     json (2.2.0)
     listen (3.2.0)
@@ -31,6 +39,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mini_portile2 (2.4.0)
+    minitest (5.12.2)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.2)
@@ -120,7 +129,10 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
+    thread_safe (0.3.6)
     tilt (2.0.10)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     webmock (3.7.6)
       addressable (>= 2.3.6)
@@ -133,6 +145,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   dotenv
   gitlab
   pronto

--- a/lib/action_command.rb
+++ b/lib/action_command.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ActionCommand < Command
+  include Logging
+
+  REQUIRED_PARAMS = %w[user_id channel_id team_id post_id trigger_id type context].freeze
+  REQUIRED_CONTEXT = %w[args response_url token].freeze
+  attr_reader(*(REQUIRED_PARAMS + REQUIRED_CONTEXT))
+
+  def initialize(params, token)
+    super
+
+    REQUIRED_CONTEXT.each do |p|
+      raise MissingParams unless context[p]
+
+      instance_variable_set("@#{p}", context[p])
+    end
+
+    raise InvalidToken if token && @token != token
+  end
+end

--- a/lib/base_job.rb
+++ b/lib/base_job.rb
@@ -3,4 +3,32 @@
 class BaseJob
   include SuckerPunch::Job
   include Logging
+
+  def validate_args
+    return true unless args.empty?
+
+    respond(lines: ["Invalid URL, please provide a URL to GitLab issue list and apply at least one filter!"])
+    false
+  end
+
+  def load_issues
+    time_sum = 0
+    issues_without_estimates = []
+
+    issues = Gitlab.issues(nil, args).auto_paginate
+    issues.each do |issue|
+      time_sum += issue.time_stats.time_estimate
+      issues_without_estimates << issue.web_url if issue.time_stats.time_estimate.zero?
+    end
+
+    [time_sum, issues, issues_without_estimates]
+  end
+
+  def respond(args)
+    command.respond(response_options.merge(args))
+  end
+
+  def response_options
+    { username: 'GitLab', icon: "https://about.gitlab.com/images/press/logo/png/gitlab-icon-rgb.png" }
+  end
 end

--- a/lib/command.rb
+++ b/lib/command.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Command
+  include Logging
+
+  class InvalidToken < StandardError; end
+  class MissingParams < StandardError; end
+
+  def initialize(params, token)
+    @token = token
+    logger.warn "Not validating slash command because token is missing" unless token
+    required_params.each do |p|
+      raise MissingParams unless params[p]
+
+      instance_variable_set("@#{p}", params[p])
+    end
+  end
+
+  def required_params
+    self.class.const_get(:REQUIRED_PARAMS)
+  end
+
+  def respond(lines:, response_type: 'ephemeral', icon: nil, username:, attachments: [])
+    res = HTTParty.post @response_url,
+                        body: JSON.dump(text: lines.join("\n"), response_type: response_type, icon_url: icon, username: username, attachments: attachments),
+                        headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+    logger.error "Unable to post response to Mattermost: #{res}" if res.code != 200
+  end
+end

--- a/lib/list_unestimated_job.rb
+++ b/lib/list_unestimated_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ListUnestimatedJob < BaseJob
+  include ActiveSupport::Inflector
+  attr_reader :command, :args
+
+  def perform(command)
+    @command = command
+    @args = command.args
+
+    validate_args || return
+
+    (_, _, issues_without_estimates) = load_issues
+
+    return if issues_without_estimates.empty?
+
+    respond(lines: ["Issues missing estimations:"] + issues_without_estimates)
+  rescue StandardError => e
+    respond(lines: [e.message] + e.backtrace)
+  end
+end

--- a/lib/slash_command.rb
+++ b/lib/slash_command.rb
@@ -1,29 +1,16 @@
 # frozen_string_literal: true
 
-class SlashCommand
+class SlashCommand < Command
   include Logging
 
   REQUIRED_PARAMS = %w[channel_id channel_name command response_url team_domain team_id text token trigger_id user_id user_name].freeze
   attr_reader(*REQUIRED_PARAMS)
 
-  class InvalidToken < StandardError; end
-  class MissingParams < StandardError; end
-
   def initialize(params, token)
     @token = token
-    logger.warn "Not validating slash command because token is missing" unless token
-    REQUIRED_PARAMS.each do |p|
-      raise MissingParams unless params[p]
 
-      instance_variable_set("@#{p}", params[p])
-    end
+    super
+
     raise InvalidToken if token && @token != token
-  end
-
-  def respond(lines:, response_type: 'ephemeral', icon: nil, username:)
-    res = HTTParty.post @response_url,
-                        body: JSON.dump(text: lines.join("\n"), response_type: response_type, icon_url: icon, username: username),
-                        headers: { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
-    logger.error "Unable to post response to Mattermost: #{res}" if res.code != 200
   end
 end

--- a/spec/lib/estimates_job_spec.rb
+++ b/spec/lib/estimates_job_spec.rb
@@ -8,21 +8,65 @@ RSpec.describe EstimatesJob do
     expect(Gitlab).to receive(:issues).with(nil, assignee_username: "dominik.sander", labels: "Release",
                                                  milestone: "Release 6.0", scope: "all", state: "opened").and_return(gitlab_mock)
 
-    expect(job).to receive(:respond).with(lines: array_including("1 issues: **1h**"), response_type: 'in_channel')
-    expect(job).to receive(:respond).with(lines: array_including("Issues missing estimations:"))
-    job.perform(SlashCommand.new(params, nil))
+    expect(job).to receive(:respond).with(attachments: [
+                                            { actions: [],
+                                              fields: [{ short: true, title: "Assignee username", value: "dominik.sander" },
+                                                       { short: true, title: "Milestone", value: "Release 6.0" },
+                                                       { short: true, title: "Labels", value: "Release" },
+                                                       { short: true, title: "Scope", value: "all" },
+                                                       { short: true, title: "State", value: "opened" }],
+                                              text: "#### 1h",
+                                              title: "Time estimation summary for 1 issues",
+                                              title_link: params['text'] }
+                                          ],
+                                          lines: [],
+                                          response_type: "in_channel")
+
+    job.perform(SlashCommand.new(params, nil), "http:/hostname.local")
+  end
+
+  it 'includes an action if at least one issues does not have an estimation' do
+    expect(job).to receive(:load_issues).and_return([3600, [1, 2], ["https://gitlab.com/issues/1"]])
+
+    expect(job).to receive(:respond).with(attachments: [
+                                            {
+                                              actions: [
+                                                { integration: { context: { args: { assignee_username: "dominik.sander",
+                                                                                    labels: "Release",
+                                                                                    milestone: "Release 6.0",
+                                                                                    scope: "all",
+                                                                                    state: "opened" },
+                                                                            response_url: "https://mattermost.local/hooks/commands/rri1ri1s53gu5g37kckk46qsfh",
+                                                                            token: nil },
+                                                                 url: "http:/hostname.local/api/actions/list_unestimated" },
+                                                  name: "Show 1 issues without estimates" }
+                                              ],
+                                              fields: [{ short: true, title: "Assignee username", value: "dominik.sander" },
+                                                       { short: true, title: "Milestone", value: "Release 6.0" },
+                                                       { short: true, title: "Labels", value: "Release" },
+                                                       { short: true, title: "Scope", value: "all" },
+                                                       { short: true, title: "State", value: "opened" }],
+                                              text: "#### 1h",
+                                              title: "Time estimation summary for 2 issues",
+                                              title_link: params['text']
+                                            }
+                                          ],
+                                          lines: [],
+                                          response_type: "in_channel")
+
+    job.perform(SlashCommand.new(params, nil), "http:/hostname.local")
   end
 
   it 'warns if no filters are given' do
     expect(job).to receive(:respond).with(lines: array_including(/Invalid URL/))
-    job.perform(SlashCommand.new(params.merge('text' => 'notaurl'), nil))
+    job.perform(SlashCommand.new(params.merge('text' => 'notaurl'), nil), "http:/hostname.local")
   end
 
   it 'sends exceptions back to the requester' do
     expect(Gitlab).to receive(:issues).and_raise(ArgumentError, "woups")
 
-    expect(job).to receive(:respond).with(lines: array_including("woups"), response_type: 'in_channel')
-    job.perform(SlashCommand.new(params, nil))
+    expect(job).to receive(:respond).with(lines: array_including("woups"))
+    job.perform(SlashCommand.new(params, nil), "http:/hostname.local")
   end
 
   it 'respond calls the command' do

--- a/spec/lib/list_unestimated_job_spec.rb
+++ b/spec/lib/list_unestimated_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe ListUnestimatedJob do
+  let(:job) { ListUnestimatedJob.new }
+
+  it 'sends the report' do
+    expect(job).to receive(:load_issues).and_return([nil, nil, ["http://gitlab.com/issues/1"]])
+    expect(job).to receive(:respond).with(lines: ["Issues missing estimations:", "http://gitlab.com/issues/1"])
+
+    job.perform(ActionCommand.new(unestimated_params, nil))
+  end
+
+  it 'warns if no filters are given' do
+    expect(job).to receive(:respond).with(lines: array_including(/Invalid URL/))
+    params = unestimated_params
+    params['context']['args'] = {}
+    job.perform(ActionCommand.new(params, nil))
+  end
+
+  it 'sends exceptions back to the requester' do
+    expect(Gitlab).to receive(:issues).and_raise(ArgumentError, "woups")
+
+    expect(job).to receive(:respond).with(lines: array_including("woups"))
+    job.perform(ActionCommand.new(unestimated_params, nil))
+  end
+end

--- a/spec/lib/slash_command_spec.rb
+++ b/spec/lib/slash_command_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SlashCommand do
   it "sends a response to mattermost" do
     stub_request(:post, "https://mattermost.local/hooks/commands/rri1ri1s53gu5g37kckk46qsfh")
       .with(
-        body: "{\"text\":\"Hello\\nworld\",\"response_type\":\"ephemeral\",\"icon_url\":\"http://icon.com\",\"username\":\"test\"}",
+        body: "{\"text\":\"Hello\\nworld\",\"response_type\":\"ephemeral\",\"icon_url\":\"http://icon.com\",\"username\":\"test\",\"attachments\":[]}",
         headers: {
           'Accept' => 'application/json',
           'Content-Type' => 'application/json'

--- a/spec/requests/list_unestimated_spec.rb
+++ b/spec/requests/list_unestimated_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe '/api/actions/list_unestimated' do
+  it 'works with the correct parameters' do
+    expect(ListUnestimatedJob).to receive(:perform_async)
+    post '/api/actions/list_unestimated', unestimated_params, {}
+    expect(response.status).to eq(200)
+  end
+
+  it 'it fails with the wrong token' do
+    tkn = ENV.delete('ESTIMATES_TOKEN')
+    ENV['ESTIMATES_TOKEN'] = 'something'
+    post '/api/actions/list_unestimated', unestimated_params, {}
+    ENV['ESTIMATES_TOKEN'] = tkn
+    expect(response.status).to eq(403)
+  end
+
+  it 'errors when parameters are missing' do
+    post '/api/actions/list_unestimated', nil, {}
+    expect(response.status).to eq(422)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,25 @@ RSpec.configure do |config|
       'user_name' => 'dsander' }
   end
 
+  def unestimated_params
+    { "user_id" => "jgwefzak6cxtri6ia",
+      "channel_id" => "123",
+      "team_id" => "",
+      "post_id" => "wmwfe9yn5gykamhrc",
+      "trigger_id" => "cjEzeGVrMWQ1N3Iamd3ZWZ6bW9vdGdxOGQ0YWs2Y3h0cmk2aWE6MTQUNIcTBnbG5XZWV1cnpyZkZXVVg4bzhOUmxwQ216VjIrQ1dJZkE=",
+      "type" => "",
+      "data_source" => "",
+      "context" =>
+      { "args" =>
+        { "assignee_username" => "dominik.sander",
+          "labels" => "Release",
+          "milestone" => "Release 6.0",
+          "scope" => "all",
+          "state" => "opened" },
+        'response_url' => 'https://mattermost.local/hooks/commands/rri1ri1s53gu5g37kckk46qsfh',
+        "token" => "9o6d8ijdqj8q7piu6dx3jig34a" } }
+  end
+
   # config.profile_examples = 10
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Instead of always sending a possibly large list of issues without
estimations we show a "action" button that will show the list of
unestimated issues to only the requester.