### PR TITLE
Misc fixes for production setups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           bundle install --jobs 4 --retry 3 --without default development test
           export PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")"
           export PRONTO_GITHUB_ACCESS_TOKEN="${{ secrets.GITHUB_TOKEN }}"
-          bundle exec pronto run -f github_status github_pr -c origin/master
+          bundle exec pronto run -f github_status github_pr -c origin/master -r rubocop
   specs:
     runs-on: ubuntu-18.04
     steps:

--- a/CHECKS
+++ b/CHECKS
@@ -1,0 +1,3 @@
+WAIT=1
+
+/  Mattermost

--- a/boot.rb
+++ b/boot.rb
@@ -3,6 +3,10 @@
 require 'zeitwerk'
 require 'sucker_punch'
 require 'gitlab'
+require 'roda'
+require "rack/attack"
+require "active_support/core_ext/string/inflections"
+require 'logger'
 
 if ENV['RACK_ENV'] == 'development'
   require 'dotenv'

--- a/lib/estimates_job.rb
+++ b/lib/estimates_job.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/inflections"
-
 class EstimatesJob < BaseJob
   include ActiveSupport::Inflector
   attr_reader :command, :args

--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Logging
-  def self.initialize_logger(log_target = STDOUT, log_level = Logger::INFO)
+  def self.initialize_logger(log_target = STDOUT, log_level = Logger::DEBUG)
     @logger = Logger.new(log_target)
-    @logger.level = ENV["RACK_ENV"] == 'development' ? Logger::DEBUG : log_level
+    @logger.level = log_level
     @logger
   end
 

--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'logger'
-
 module Logging
   def self.initialize_logger(log_target = STDOUT, log_level = Logger::INFO)
     @logger = Logger.new(log_target)

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -8,7 +8,7 @@ class Server < Roda
   plugin :json_parser
 
   def hostname(req)
-    "#{req.env['rack.url_scheme']}://#{req.env['HTTP_HOST']}"
+    ENV.fetch("DOMAIN", "#{req.env['rack.url_scheme']}://#{req.env['HTTP_HOST']}")
   end
 
   route do |r|

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'roda'
-require "rack/attack"
-
 class Server < Roda
   use Rack::Attack
   include Logging


### PR DESCRIPTION
Allow to configure the full hostname including scheme via ENV variable

In some situations (double proxying with the second proxy not properly
setting the X-Forwarded-* headers) we can not get the actual, external
domain name and schema. Setting the `DOMAIN` environment variables
allows overriding the derived values.

------------------------------


Add CHECKS file for dokku

------------------------------

Default to DEBUG logging in all environments

------------------------------

Move all `require` calls to ``boot.rb``

Fixes load order issues, in some cases code using dependencies could be
called before requiring the needed files.